### PR TITLE
Update to version of cviebrock/eloquent-sluggable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.*",
-        "cviebrock/eloquent-sluggable": "1.0.*",
+        "cviebrock/eloquent-sluggable": "2.*",
         "judev/php-htmltruncator": "dev-master",
         "fzaninotto/faker": "1.3.*"
     },


### PR DESCRIPTION
Updated the version of cviebrock/eloquent-sluggable to "2.*" since the current stable version of that package is "2.0.2"
